### PR TITLE
fix: fix r->l in accents

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ function cebolinha(string) {
     .replace(/r(?=(l|L))/g, "u")
     .replace(/R(?=(l|L))/g, "U")
     .replace(/r+(?!\b)/g, "l")
-    .replace(/R+(?!\b)/g, "L");
+    .replace(/R+(?!\b)/g, "L")
+    .replace(/r(?=[À-ÖØ-ö])/g, "l")
+    .replace(/R(?=[À-ÖØ-ö])/g, "L");
 }
 
 module.exports = cebolinha;

--- a/test.js
+++ b/test.js
@@ -19,5 +19,12 @@ describe("cebolinha", () => {
     expect(cebolinha("PRATO")).toBe("PLATO");
     expect(cebolinha("RATO")).toBe("LATO");
   });
+  it("deveria funcionar com acentos", () => {
+    expect(cebolinha("três")).toBe("tlês");
+    expect(cebolinha("prêmio")).toBe("plêmio");
+    expect(cebolinha("páreo")).toBe("páleo");
+    expect(cebolinha("miríade")).toBe("milíade");
+    expect(cebolinha("TRÊS")).toBe("TLÊS");
+    expect(cebolinha("PÁREO")).toBe("PÁLEO");
+  });
 });
-


### PR DESCRIPTION
Esse PR foi feito para consertar um caso não coberto pelo regex: Quando temos um r antes de uma vogal acentuada. 
Ex: prêmio, páreo...